### PR TITLE
Update Provider for Omron API changes

### DIFF
--- a/src/Provider/Omron.php
+++ b/src/Provider/Omron.php
@@ -19,6 +19,11 @@ class Omron extends AbstractProvider
     protected $authHostname;
 
     /**
+     * @var string
+     */
+    protected $tokenHostname;
+
+    /**
      * @var string Key used in a token response to identify the resource owner.
      */
     const ACCESS_TOKEN_RESOURCE_OWNER_ID = 'sub';
@@ -42,7 +47,7 @@ class Omron extends AbstractProvider
      */
     public function getBaseAccessTokenUrl(array $params)
     {
-        return $this->authHostname . '/connect/token';
+        return $this->tokenHostname . '/connect/token';
     }
 
     /**
@@ -136,7 +141,7 @@ class Omron extends AbstractProvider
     {
         $options = $this->optionProvider->getAccessTokenOptions($this->getAccessTokenMethod(), []);
         $uri = $this->appendQuery(
-            $this->authHostname . '/connect/revocation',
+            $this->tokenHostname . '/connect/revocation',
             $this->buildQueryString(['token' => $accessToken->getToken(), 'token_type_hint' => 'access_token'])
         );
         $request = $this->getRequest(self::METHOD_POST, $uri, $options);

--- a/test/src/Provider/OmronTest.php
+++ b/test/src/Provider/OmronTest.php
@@ -25,6 +25,8 @@ class OmronTest extends TestCase
         $this->provider = new Omron([
             'clientId' => 'mock_client_id',
             'clientSecret' => 'mock_secret',
+            'authHostname' => 'https://stg-oauth-website.ohiomron.com',
+            'tokenHostname' => 'https://stg-oauth.ohiomron.com/stg',
             'redirectUri' => 'none',
         ]);
 
@@ -69,6 +71,8 @@ class OmronTest extends TestCase
     {
         $url = $this->provider->getAuthorizationUrl();
         $uri = parse_url($url);
+
+        $this->assertEquals('stg-oauth-website.ohiomron.com', $uri['host']);
         $this->assertEquals('/connect/authorize', $uri['path']);
     }
 
@@ -77,14 +81,16 @@ class OmronTest extends TestCase
         $params = [];
         $url = $this->provider->getBaseAccessTokenUrl($params);
         $uri = parse_url($url);
-        $this->assertEquals('/connect/token', $uri['path']);
+
+        $this->assertEquals('stg-oauth.ohiomron.com', $uri['host']);
+        $this->assertEquals('/stg/connect/token', $uri['path']);
     }
 
     public function testGetResourceOwnerDetailsUrl()
     {
         $url = $this->provider->getResourceOwnerDetailsUrl($this->token);
         $uri = parse_url($url);
-        $this->assertEquals('/v2/user', $uri['path']);
+        $this->assertEquals('', $uri['path']);
         $this->assertEquals('action=getdevice&access_token=mock_token', $uri['query']);
     }
 


### PR DESCRIPTION
Omron is updating their API, and their authentication and token addresses are no longer the same. Update the provider to support this new behavior.